### PR TITLE
support include domain type parse raml

### DIFF
--- a/lib/raml/parser.rb
+++ b/lib/raml/parser.rb
@@ -11,7 +11,14 @@ module Raml
 
     def initialize
       Psych.add_domain_type 'include', 'include' do |_, value|
-        File.read(value)
+        content = File.read(value)
+
+        case File.extname(value)
+        when *%w[.yaml .yml .raml]
+          YAML.load(content)
+        else
+          content
+        end
       end
     end
 

--- a/lib/raml/parser/resource.rb
+++ b/lib/raml/parser/resource.rb
@@ -11,6 +11,8 @@ module Raml
       extend Forwardable
       include Raml::Parser::Util
 
+      BASIC_ATTRIBUTES = %w[display_name description]
+
       METHODS = %w[get put post delete]
 
       attr_accessor :parent_node, :resource, :trait_names, :attributes
@@ -24,6 +26,7 @@ module Raml
         @parent_node = parent_node
         @resource = Raml::Resource.new(@parent_node, uri_partial)
         @attributes = prepare_attributes(attributes)
+
         apply_resource_type
         parse_attributes
         resource
@@ -37,6 +40,8 @@ module Raml
             case key
             when /^\//
               resource.resources << Raml::Parser::Resource.new(self).parse(resource, key, value)
+            when *BASIC_ATTRIBUTES
+              resource.send("#{key}=".to_sym, value)
             when *METHODS
               resource.methods << Raml::Parser::Method.new(self).parse(key, value)
             when 'is'

--- a/lib/raml/parser/response.rb
+++ b/lib/raml/parser/response.rb
@@ -23,6 +23,8 @@ module Raml
           attributes.each do |key, value|
             key = underscore(key)
             case key
+            when 'description'
+              response.send("#{key}=".to_sym, value)
             when 'body'
               parse_bodies(value)
             else

--- a/lib/raml/resource.rb
+++ b/lib/raml/resource.rb
@@ -1,6 +1,6 @@
 module Raml
   class Resource
-    attr_accessor :parent, :methods, :uri_partial, :resources
+    attr_accessor :parent, :methods, :uri_partial, :resources, :display_name, :description
 
     def initialize(parent, uri_partial)
       @parent = parent

--- a/lib/raml/response.rb
+++ b/lib/raml/response.rb
@@ -1,6 +1,6 @@
 module Raml
   class Response
-    attr_accessor :code, :bodies
+    attr_accessor :code, :bodies, :description
 
     def initialize(code)
       @code = code

--- a/spec/lib/raml/parser/resource_spec.rb
+++ b/spec/lib/raml/parser/resource_spec.rb
@@ -25,6 +25,16 @@ describe Raml::Parser::Resource do
       end
     end
 
+
+    { 'display_name' => 'Catgeory', 'description' => 'resource description' }.each do |key, value|
+      context "attribute: #{key}" do
+        let(:attributes) { { key => value } }
+        it 'should pass through display_name attribute' do
+          subject.send(key.to_sym).should == value
+        end
+      end
+    end
+
     %w[get put post delete].each do |method|
       context method do
         let(:attributes) { { method => 'method attributess' } }


### PR DESCRIPTION
Added some feature:
- support include domain type parse raml or yaml file
- resource append `display_name`, 'description` attribute
- response append `description` attribute

The most important is the first one, for example:

**index.raml**

``` raml
#%RAML 0.8

---
title: Example API
baseUri: http://www.example.com
version: 1

/user: !include user/index.raml
```

**user/index.raml**

``` raml
displayName: User Section
description: All about user api: create, edit, remove etc.

/profile: !include user/_profile.raml
```

Please review the code, thanx
