### PR TITLE
Update RSpec to new syntax

### DIFF
--- a/spec/lib/core_ext/hash_spec.rb
+++ b/spec/lib/core_ext/hash_spec.rb
@@ -4,21 +4,21 @@ describe Hash do
 
   describe '#deep_merge' do
     subject { { key: 'left' }.deep_merge({ key: 'right'}) }
-    it { should == { key: 'right' } }
+    it { is_expected.to eq({ key: 'right' }) }
 
     context 'nested hash' do
       subject { { key: { key: { key: 'left' } } }.deep_merge({ key: { key: { key: 'right' } } }) }
-      it { should == { key: { key: { key: 'right' } } } }
+      it { is_expected.to eq({ key: { key: { key: 'right' } } }) }
     end
 
     context 'nested hash with nil on original hash' do
       subject { { key: { key: { key: nil } } }.deep_merge({ key: { key: { key: 'right' } } }) }
-      it { should == { key: { key: { key: 'right' } } } }
+      it { is_expected.to eq({ key: { key: { key: 'right' } } }) }
     end
 
     context 'nested hash with nil on merged hash' do
       subject { { key: { key: { key: 'left' } } }.deep_merge({ key: { key: { key: nil } } }) }
-      it { should == { key: { key: { key: nil } } } }
+      it { is_expected.to eq({ key: { key: { key: nil } } }) }
     end
   end
 

--- a/spec/lib/raml/body_spec.rb
+++ b/spec/lib/raml/body_spec.rb
@@ -11,21 +11,21 @@ describe Raml::Body do
     let(:body) { Raml::Body.new('the content_type') }
     before { body.content_type = 'content_type' }
     subject { body.content_type }
-    it { should == 'content_type' }
+    it { is_expected.to eq('content_type') }
   end
 
   describe '#schema' do
     let(:body) { Raml::Body.new('the content_type') }
     before { body.schema = 'schema' }
     subject { body.schema }
-    it { should == 'schema' }
+    it { is_expected.to eq('schema') }
   end
 
   describe '#example' do
     let(:body) { Raml::Body.new('the content_type') }
     before { body.example = 'example' }
     subject { body.example }
-    it { should == 'example' }
+    it { is_expected.to eq('example') }
   end
 
 end

--- a/spec/lib/raml/documentation_spec.rb
+++ b/spec/lib/raml/documentation_spec.rb
@@ -6,14 +6,14 @@ describe Raml::Documentation do
     let(:documentation) { Raml::Documentation.new }
     before { documentation.title = 'the title' }
     subject { documentation.title }
-    it { should == 'the title' }
+    it { is_expected.to eq('the title') }
   end
 
   describe '#content' do
     let(:documentation) { Raml::Documentation.new }
     before { documentation.content = 'the content' }
     subject { documentation.content }
-    it { should == 'the content' }
+    it { is_expected.to eq('the content') }
   end
 
 end

--- a/spec/lib/raml/method_spec.rb
+++ b/spec/lib/raml/method_spec.rb
@@ -11,7 +11,7 @@ describe Raml::Method do
     let(:documentation) { Raml::Documentation.new }
     before { documentation.title = 'the title' }
     subject { documentation.title }
-    it { should == 'the title' }
+    it { is_expected.to eq('the title') }
   end
 
   describe '#response_code' do

--- a/spec/lib/raml/parser.rb
+++ b/spec/lib/raml/parser.rb
@@ -6,44 +6,44 @@ describe Raml::Parser do
   describe '#parse' do
     let(:raml) { File.read('spec/fixtures/basic.raml') }
     before do
-      subject.stub(:parse)
+      allow(subject).to receive(:parse)
       Raml::Parser.new.parse(raml)
     end
     subject { Raml::Parser::Root.any_instance }
 
-    it { should have_received(:stub).with(YAML.load(raml)) }
+    it { is_expected.to have_received(:stub).with(YAML.load(raml)) }
   end
 
   describe '.parse' do
     let(:raml) { File.read('spec/fixtures/basic.raml') }
     before do
-      subject.stub(:parse)
+      allow(subject).to receive(:parse)
       Raml::Parser.parse(raml)
     end
     subject { Raml::Parser.any_instance }
 
-    it { should have_received(:parse).with(raml) }
+    it { is_expected.to have_received(:parse).with(raml) }
   end
 
   describe '.parse_file' do
     let(:raml) { File.read('spec/fixtures/basic.raml') }
     before do
-      subject.stub(:parse)
+      allow(subject).to receive(:parse)
       Raml::Parser.parse_file('spec/fixtures/basic.raml')
     end
     subject { Raml::Parser.any_instance }
 
-    it { should have_received(:parse).with(raml) }
+    it { is_expected.to have_received(:parse).with(raml) }
   end
 
   describe '.parse_file' do
     before do
-      subject.stub(:parse_file)
+      allow(subject).to receive(:parse_file)
       Raml::Parser.parse_file('path/to/file.raml')
     end
     subject { Raml::Parser.any_instance }
 
-    it { should have_received(:parse_file).with('path/to/file.raml') }
+    it { is_expected.to have_received(:parse_file).with('path/to/file.raml') }
   end
 
 end

--- a/spec/lib/raml/parser/body_spec.rb
+++ b/spec/lib/raml/parser/body_spec.rb
@@ -8,7 +8,7 @@ describe Raml::Parser::Body do
   describe '#parse' do
     subject { instance.parse(type, attribute) }
 
-    it { should be_kind_of Raml::Body }
+    it { is_expected.to be_kind_of Raml::Body }
     its(:schema) { should == 'dogs' }
     its(:example) { should == 'cats' }
   end
@@ -16,7 +16,7 @@ describe Raml::Parser::Body do
   describe '#body' do
     before { instance.parse(type, attribute) }
     subject { instance.body }
-    it { should be_kind_of Raml::Body }
+    it { is_expected.to be_kind_of Raml::Body }
   end
 
 end

--- a/spec/lib/raml/parser/documentation_spec.rb
+++ b/spec/lib/raml/parser/documentation_spec.rb
@@ -7,7 +7,7 @@ describe Raml::Parser::Documentation do
     let(:trait_names) { nil }
     subject { Raml::Parser::Documentation.new.parse(attribute) }
 
-    it { should be_kind_of Raml::Documentation }
+    it { is_expected.to be_kind_of Raml::Documentation }
     its(:title) { should == 'The title' }
     its(:content) { should == 'The content' }
   end

--- a/spec/lib/raml/parser/method_spec.rb
+++ b/spec/lib/raml/parser/method_spec.rb
@@ -6,12 +6,12 @@ describe Raml::Parser::Method do
     let(:attributes) { { 'description' => 'The description', 'headers' => [{ 'key' => 'value' }], 'responses' => ['cats'], 'query_parameters' => ['dogs'] } }
     let(:parent) { double(traits: { 'cats' => { 'description' => 'Trait description', 'headers' => { 'trait_key' => 'trait_value' } } }, trait_names: nil) }
     before do
-      Raml::Parser::Response.any_instance.stub(:parse).and_return('cats')
-      Raml::Parser::QueryParameter.any_instance.stub(:parse).and_return('dogs')
+      allow_any_instance_of(Raml::Parser::Response).to receive(:parse).and_return('cats')
+      allow_any_instance_of(Raml::Parser::QueryParameter).to receive(:parse).and_return('dogs')
     end
     subject { Raml::Parser::Method.new(parent).parse('get', attributes) }
 
-    it { should be_kind_of Raml::Method }
+    it { is_expected.to be_kind_of Raml::Method }
     its(:method) { should == 'get' }
     its(:description) { should == 'The description' }
     its(:headers) { should == [ { 'key' => 'value' } ] }

--- a/spec/lib/raml/parser/query_parameter_spec.rb
+++ b/spec/lib/raml/parser/query_parameter_spec.rb
@@ -8,7 +8,7 @@ describe Raml::Parser::QueryParameter do
   describe '#parse' do
     subject { instance.parse(type, attribute) }
 
-    it { should be_kind_of Raml::QueryParameter }
+    it { is_expected.to be_kind_of Raml::QueryParameter }
     its(:description) { should == 'dogs' }
     its(:type) { should == 'cats' }
     its(:example) { should == 'birds' }
@@ -17,7 +17,7 @@ describe Raml::Parser::QueryParameter do
   describe '#query_parameter' do
     before { instance.parse(type, attribute) }
     subject { instance.query_parameter }
-    it { should be_kind_of Raml::QueryParameter }
+    it { is_expected.to be_kind_of Raml::QueryParameter }
   end
 
 end

--- a/spec/lib/raml/parser/resource_spec.rb
+++ b/spec/lib/raml/parser/resource_spec.rb
@@ -12,7 +12,7 @@ describe Raml::Parser::Resource do
 
   describe '#parse' do
     subject { instance.parse(parent_node, uri_partial, attributes) }
-    it { should be_kind_of Raml::Resource }
+    it { is_expected.to be_kind_of Raml::Resource }
 
     context 'resource' do
       before do
@@ -21,7 +21,7 @@ describe Raml::Parser::Resource do
       end
       let(:attributes) { { '/bar' => {} } }
       it 'should create a method' do
-        resource.resources.should have_received('<<').with(kind_of(Raml::Resource))
+        expect(resource.resources).to have_received('<<').with(kind_of(Raml::Resource))
       end
     end
 
@@ -47,7 +47,7 @@ describe Raml::Parser::Resource do
   describe '#resource' do
     before { instance.parse(parent_node, uri_partial, attributes) }
     subject { instance.resource }
-    it { should be_kind_of Raml::Resource }
+    it { is_expected.to be_kind_of Raml::Resource }
   end
 
 end

--- a/spec/lib/raml/parser/response_spec.rb
+++ b/spec/lib/raml/parser/response_spec.rb
@@ -9,10 +9,10 @@ describe Raml::Parser::Response do
     subject { instance.parse(code, attribute) }
 
     before do
-      Raml::Parser::Body.any_instance.stub(:parse)
+      allow_any_instance_of(Raml::Parser::Body).to receive(:parse)
     end
 
-    it { should be_kind_of Raml::Response }
+    it { is_expected.to be_kind_of Raml::Response }
     its(:code) { should == 201 }
     it 'should call through to body' do
       expect_any_instance_of(Raml::Parser::Body).to receive(:parse).with('cats', {}).once
@@ -23,7 +23,7 @@ describe Raml::Parser::Response do
   describe '#response' do
     before { instance.parse(code, attribute) }
     subject { instance.response }
-    it { should be_kind_of Raml::Response }
+    it { is_expected.to be_kind_of Raml::Response }
   end
 
 end

--- a/spec/lib/raml/parser/root_spec.rb
+++ b/spec/lib/raml/parser/root_spec.rb
@@ -7,7 +7,7 @@ describe Raml::Parser::Root do
     let(:raml) { YAML.load File.read('spec/fixtures/basic.raml') }
     subject { Raml::Parser::Root.new.parse(raml) }
 
-    it { should be_kind_of Raml::Root }
+    it { is_expected.to be_kind_of Raml::Root }
     its(:base_uri) { should == 'http://example.api.com/{version}' }
     its(:uri) { should == 'http://example.api.com/v1' }
     its(:version) { should == 'v1' }

--- a/spec/lib/raml/query_parameter_spec.rb
+++ b/spec/lib/raml/query_parameter_spec.rb
@@ -5,35 +5,35 @@ describe Raml::QueryParameter do
   describe '.new' do
     let(:query_parameter) { Raml::QueryParameter.new('name') }
     subject { query_parameter.name }
-    it { should == 'name' }
+    it { is_expected.to eq('name') }
   end
 
   describe '#name' do
     let(:query_parameter) { Raml::QueryParameter.new('name') }
     before { query_parameter.name = 'the name' }
     subject { query_parameter.name }
-    it { should == 'the name' }
+    it { is_expected.to eq('the name') }
   end
 
   describe '#description' do
     let(:query_parameter) { Raml::QueryParameter.new('name') }
     before { query_parameter.description = 'the description' }
     subject { query_parameter.description }
-    it { should == 'the description' }
+    it { is_expected.to eq('the description') }
   end
 
   describe '#type' do
     let(:query_parameter) { Raml::QueryParameter.new('name') }
     before { query_parameter.type = 'the type' }
     subject { query_parameter.type }
-    it { should == 'the type' }
+    it { is_expected.to eq('the type') }
   end
 
   describe '#example' do
     let(:query_parameter) { Raml::QueryParameter.new('name') }
     before { query_parameter.example = 'the example' }
     subject { query_parameter.example }
-    it { should == 'the example' }
+    it { is_expected.to eq('the example') }
   end
 
 end

--- a/spec/lib/raml/resource_spec.rb
+++ b/spec/lib/raml/resource_spec.rb
@@ -14,20 +14,20 @@ describe Raml::Resource do
     let(:parent) { double(uri: 'http://www.example.com') }
     let(:uri_partial) { '/cats' }
     subject { Raml::Resource.new(parent, uri_partial).uri }
-    it { should == 'http://www.example.com/cats' }
+    it { is_expected.to eq('http://www.example.com/cats') }
 
     context 'partial no slash' do
       let(:uri_partial) { 'cats' }
-      it { should == 'http://www.example.com/cats' }
+      it { is_expected.to eq('http://www.example.com/cats') }
     end
 
     context 'base trailing slash' do
       let(:parent) { double(uri: 'http://www.example.com') }
-      it { should == 'http://www.example.com/cats' }
+      it { is_expected.to eq('http://www.example.com/cats') }
 
       context 'partial no slash' do
         let(:uri_partial) { 'cats' }
-        it { should == 'http://www.example.com/cats' }
+        it { is_expected.to eq('http://www.example.com/cats') }
       end
     end
   end

--- a/spec/lib/raml/response_spec.rb
+++ b/spec/lib/raml/response_spec.rb
@@ -12,14 +12,14 @@ describe Raml::Response do
     let(:response) { Raml::Response.new(201) }
     before { response.code = 'the code' }
     subject { response.code }
-    it { should == 'the code' }
+    it { is_expected.to eq('the code') }
   end
 
   describe '#bodies' do
     let(:response) { Raml::Response.new(201) }
     before { response.bodies = 'the bodies' }
     subject { response.bodies }
-    it { should == 'the bodies' }
+    it { is_expected.to eq('the bodies') }
   end
 
 end

--- a/spec/lib/raml/root_spec.rb
+++ b/spec/lib/raml/root_spec.rb
@@ -4,33 +4,33 @@ describe Raml::Root do
 
   describe '#resources' do
     subject { Raml::Root.new.resources }
-    it { should be_kind_of Array }
+    it { is_expected.to be_kind_of Array }
   end
 
   describe '#documentation' do
     subject { Raml::Root.new.documentation }
-    it { should be_kind_of Array }
+    it { is_expected.to be_kind_of Array }
   end
 
   describe '#uri' do
     let(:root) { Raml::Root.new }
     before { root.base_uri = 'http://example.com' }
     subject { root.uri }
-    it { should == 'http://example.com' }
+    it { is_expected.to eq('http://example.com') }
   end
 
   describe '#title' do
     let(:root) { Raml::Root.new }
     before { root.title = 'My RAML' }
     subject { root.title }
-    it { should == 'My RAML' }
+    it { is_expected.to eq('My RAML') }
   end
 
   describe '#version' do
     let(:root) { Raml::Root.new }
     before { root.version = '1.0' }
     subject { root.version }
-    it { should == '1.0' }
+    it { is_expected.to eq('1.0') }
   end
 
 end


### PR DESCRIPTION
This PR updates the RSpec expectation syntax to match that of RSpec 3 instead of the older `should` syntax.