### PR TITLE
Refactor some multi-line methods into single line

### DIFF
--- a/lib/raml/method.rb
+++ b/lib/raml/method.rb
@@ -10,19 +10,11 @@ module Raml
     end
 
     def response_codes
-      [].tap do |codes|
-        responses.each do |response|
-          codes << response.code
-        end
-      end
+      responses.map {|responses| response.code }
     end
 
     def content_types
-      [].tap do |types|
-        responses.each do |response|
-          types << response.content_types
-        end
-      end.flatten.uniq
+      responses.map {|response| response.content_type }.flatten.uniq
     end
 
   end

--- a/lib/raml/resource.rb
+++ b/lib/raml/resource.rb
@@ -3,10 +3,10 @@ module Raml
     attr_accessor :parent, :methods, :uri_partial, :resources
 
     def initialize(parent, uri_partial)
-      @parent = parent
+      @parent      = parent
       @uri_partial = uri_partial
-      @methods = []
-      @resources = []
+      @methods     = []
+      @resources   = []
     end
 
     def path

--- a/lib/raml/response.rb
+++ b/lib/raml/response.rb
@@ -3,16 +3,12 @@ module Raml
     attr_accessor :code, :bodies
 
     def initialize(code)
-      @code = code
+      @code   = code
       @bodies = []
     end
 
     def content_types
-      [].tap do |types|
-        bodies.each do |body|
-          types << body.content_type
-        end
-      end.uniq
+      bodies.map {|body| body.content_type }.uniq
     end
 
   end


### PR DESCRIPTION
There were a number of methods that were using nested blocks when an `Enumerable#map` suffices. This PR implements these methods using `Enumerable#map` and also makes minor changes to formatting for readability.