### PR TITLE
Bump version to 0.5 for release

### DIFF
--- a/lib/raml/version.rb
+++ b/lib/raml/version.rb
@@ -1,3 +1,3 @@
 module Raml
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
After merging #11, it is necessary to release a new version that incorporates that change. This PR increments the version number from 0.0.4 to 0.0.5 in the version file.