### PR TITLE
Support media type root key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ rvm:
   - 2.1.8
   - 2.2.0
   - 2.3.0
+branches:
+  only:
+    - master
 

--- a/lib/raml/parser/root.rb
+++ b/lib/raml/parser/root.rb
@@ -9,7 +9,7 @@ module Raml
     class Root
       include Raml::Parser::Util
 
-      BASIC_ATTRIBUTES = %w[title base_uri version base_uri_parameters]
+      BASIC_ATTRIBUTES = %w[title base_uri version base_uri_parameters media_type]
 
       attr_accessor :root, :traits, :resource_types, :attributes
 

--- a/lib/raml/root.rb
+++ b/lib/raml/root.rb
@@ -1,6 +1,7 @@
 module Raml
   class Root
-    attr_accessor :title, :base_uri, :version, :resources, :documentation, :base_uri_parameters
+    attr_accessor :title, :base_uri, :version, :resources, :documentation,
+                  :base_uri_parameters, :media_type
 
     def initialize
       @resources = []

--- a/spec/fixtures/all-the-things.raml
+++ b/spec/fixtures/all-the-things.raml
@@ -7,6 +7,7 @@ baseUriParameters:
     description: The deployed environment
     type: String
 version: v1
+mediaType: application/json
 documentation:
   - title: RAML Baml
     content: |

--- a/spec/fixtures/basic.raml
+++ b/spec/fixtures/basic.raml
@@ -7,6 +7,7 @@ baseUriParameters:
     description: The deployed environment
     type: String
 version: v1
+mediaType: application/json
 traits:
   - paged:
       queryParameters:

--- a/spec/lib/raml/parser/root_spec.rb
+++ b/spec/lib/raml/parser/root_spec.rb
@@ -14,6 +14,7 @@ describe Raml::Parser::Root do
     its(:base_uri_parameters) do
       should == {"environment" => { "description"=>"The deployed environment", "type"=>"String" }}
     end
+    its(:media_type) { should == "application/json" }
     its('resources.count') { should == 1 }
     its('resources.first.methods.count') { should == 2 }
     its('resources.first.methods.first.responses.count') { should == 0 }

--- a/spec/lib/raml/root_spec.rb
+++ b/spec/lib/raml/root_spec.rb
@@ -42,7 +42,7 @@ describe Raml::Root do
 
   describe '#media_type' do
     let(:root) { Raml::Root.new }
-    before { root.base_uri_parameters = 'application/json' }
+    before { root.media_type = 'application/json' }
     subject { root.media_type }
     it { is_expected.to eq('application/json') }
   end

--- a/spec/lib/raml/root_spec.rb
+++ b/spec/lib/raml/root_spec.rb
@@ -39,4 +39,11 @@ describe Raml::Root do
     subject { root.base_uri_parameters }
     it { is_expected.to eq('') }
   end
+
+  describe '#media_type' do
+    let(:root) { Raml::Root.new }
+    before { root.base_uri_parameters = 'application/json' }
+    subject { root.media_type }
+    it { is_expected.to eq('application/json') }
+  end
 end


### PR DESCRIPTION
This PR adds support for `mediaType` as a root key. It also sets Travis to only run against master so feature branches in development don't spam us with failures.