### PR TITLE
Change #methods to #http_methods

### DIFF
--- a/lib/raml/parser/resource.rb
+++ b/lib/raml/parser/resource.rb
@@ -11,7 +11,7 @@ module Raml
       extend Forwardable
       include Raml::Parser::Util
 
-      METHODS = %w[get put post delete]
+      HTTP_METHODS = %w[get put post delete]
 
       attr_accessor :parent_node, :resource, :trait_names, :attributes
       def_delegators :@parent, :traits, :resource_types
@@ -37,8 +37,8 @@ module Raml
             case key
             when /^\//
               resource.resources << Raml::Parser::Resource.new(self).parse(resource, key, value)
-            when *METHODS
-              resource.methods << Raml::Parser::Method.new(self).parse(key, value)
+            when *HTTP_METHODS
+              resource.http_methods << Raml::Parser::Method.new(self).parse(key, value)
             when 'is'
               @trait_names = value
             else

--- a/lib/raml/resource.rb
+++ b/lib/raml/resource.rb
@@ -1,12 +1,12 @@
 module Raml
   class Resource
-    attr_accessor :parent, :methods, :uri_partial, :resources
+    attr_accessor :parent, :http_methods, :uri_partial, :resources
 
     def initialize(parent, uri_partial)
-      @parent      = parent
-      @uri_partial = uri_partial
-      @methods     = []
-      @resources   = []
+      @parent       = parent
+      @uri_partial  = uri_partial
+      @http_methods = []
+      @resources    = []
     end
 
     def path

--- a/lib/raml/version.rb
+++ b/lib/raml/version.rb
@@ -1,3 +1,3 @@
 module Raml
-  VERSION = '0.0.7'
+  VERSION = '1.0.0'
 end

--- a/spec/lib/raml/parser/root_spec.rb
+++ b/spec/lib/raml/parser/root_spec.rb
@@ -17,23 +17,23 @@ describe Raml::Parser::Root do
     its(:media_type) { should == "application/json" }
     its(:secured_by) { should == [ "authenticationHeader" ] }
     its('resources.count') { should == 1 }
-    its('resources.first.methods.count') { should == 2 }
-    its('resources.first.methods.first.responses.count') { should == 0 }
-    its('resources.first.methods.first.query_parameters.count') { should == 2 }
+    its('resources.first.http_methods.count') { should == 2 }
+    its('resources.first.http_methods.first.responses.count') { should == 0 }
+    its('resources.first.http_methods.first.query_parameters.count') { should == 2 }
     its('documentation.count') { should == 0 }
-    its('resources.first.resources.first.methods.first.responses.first.bodies.first.example') do
+    its('resources.first.resources.first.http_methods.first.responses.first.bodies.first.example') do
       should include '{"artist":"Pink Floyd", "title":"Wish You Were Here"}'
     end
 
     context 'trait-inherited attributes' do
-      subject { Raml::Parser::Root.new.parse(raml).resources.first.methods.first.query_parameters.first }
+      subject { Raml::Parser::Root.new.parse(raml).resources.first.http_methods.first.query_parameters.first }
       its(:name) { should == 'pages' }
       its(:description) { should == 'The number of pages to return' }
       its(:type) { should == 'number' }
     end
 
     context 'non trait-inherited attributes' do
-      subject { Raml::Parser::Root.new.parse(raml).resources.first.methods.first.query_parameters.last }
+      subject { Raml::Parser::Root.new.parse(raml).resources.first.http_methods.first.query_parameters.last }
       its(:name) { should == 'genre' }
       its(:description) { should == 'filter the songs by genre' }
       its(:type) { should == nil }

--- a/spec/lib/raml/resource_spec.rb
+++ b/spec/lib/raml/resource_spec.rb
@@ -7,7 +7,7 @@ describe Raml::Resource do
     subject { Raml::Resource.new(parent, '/cats') }
     its(:parent) { should == parent }
     its(:uri_partial) { should == '/cats' }
-    its(:methods) { should == [] }
+    its(:http_methods) { should == [] }
   end
 
   describe '#uri' do


### PR DESCRIPTION
In the current API, the #methods method is defined to return the HTTP methods accepted by a particular endpoint. However, this overwrites the Object#methods method, which can be inconvenient, especially for debugging purposes. This PR changes the name of #methods to #http_methods and increments the version to 1.0, in accordance with Semver, to reflect a breaking change.