### PR TITLE
Handle URI parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in raml-rb.gemspec
 gemspec
+
+gem "byebug"

--- a/lib/raml/parser/resource.rb
+++ b/lib/raml/parser/resource.rb
@@ -41,6 +41,8 @@ module Raml
               resource.http_methods << Raml::Parser::Method.new(self).parse(key, value)
             when 'is'
               @trait_names = value
+            when 'uri_parameters'
+              @uri_parameters = value
             else
               raise UnknownAttributeError.new "Unknown resource key: #{key}"
             end

--- a/lib/raml/parser/root.rb
+++ b/lib/raml/parser/root.rb
@@ -49,7 +49,7 @@ module Raml
 
         def parse_documentation(documentations)
           documentations.each do |documentation_attributes|
-            root.documentations << Raml::Parser::Documentation.new.parse(documentation_attributes)
+            root.documentation << Raml::Parser::Documentation.new.parse(documentation_attributes)
           end
         end
 

--- a/lib/raml/version.rb
+++ b/lib/raml/version.rb
@@ -1,3 +1,3 @@
 module Raml
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/fixtures/all-the-things.raml
+++ b/spec/fixtures/all-the-things.raml
@@ -37,6 +37,9 @@ traits:
         description: filter the songs by genre
   post:
   /{songId}:
+    uriParameters:
+      songId:
+        type: integer
     get:
       responses:
         200:

--- a/spec/fixtures/basic.raml
+++ b/spec/fixtures/basic.raml
@@ -35,6 +35,9 @@ traits:
         description: filter the songs by genre
   post:
   /{songId}:
+    uriParameters:
+      songId:
+        type: integer
     get:
       responses:
         200:


### PR DESCRIPTION
This PR enables the uriParameters key:
```raml
/songs/{songId}:
  uriParameters:
    songId:
      type: integer
```
It adds a `uri_parameters` attribute to the resource.