### PR TITLE
Support schemas as root key

### DIFF
--- a/lib/raml/parser/root.rb
+++ b/lib/raml/parser/root.rb
@@ -9,7 +9,7 @@ module Raml
     class Root
       include Raml::Parser::Util
 
-      BASIC_ATTRIBUTES = %w[title base_uri version base_uri_parameters media_type secured_by security_schemes types]
+      BASIC_ATTRIBUTES = %w[title base_uri version base_uri_parameters media_type secured_by security_schemes types schemas]
 
       attr_accessor :root, :traits, :resource_types, :attributes
 
@@ -68,7 +68,6 @@ module Raml
             end
           end
         end
-
     end
   end
 end

--- a/lib/raml/root.rb
+++ b/lib/raml/root.rb
@@ -1,7 +1,8 @@
 module Raml
   class Root
     attr_accessor :title, :base_uri, :version, :resources, :documentation, :types,
-                  :base_uri_parameters, :media_type, :security_schemes, :secured_by
+                  :base_uri_parameters, :media_type, :security_schemes, :secured_by,
+                  :schemas
 
     def initialize
       @resources = []

--- a/spec/fixtures/basic.raml
+++ b/spec/fixtures/basic.raml
@@ -24,11 +24,10 @@ traits:
         pages:
           description: The number of pages to return
           type: number
-  - secured: !include http://raml-example.com/secured.yml
   - notApplied:
       fake: value
 /songs:
-  is: [ paged, secured ]
+  is: [ paged ]
   get:
     queryParameters:
       genre:

--- a/spec/fixtures/basic_raml_with_schemas.raml
+++ b/spec/fixtures/basic_raml_with_schemas.raml
@@ -1,0 +1,50 @@
+#%RAML 0.8
+---
+title: e-BookMobile API
+baseUri: http://api.e-bookmobile.com/{version}
+version: 1.2
+
+schemas:
+  Author: |
+    {
+      "$schema": "http://json-schema.org/schema",
+      "type": "object",
+      "description: "An author",
+      "properties": {
+        "id": { "type": "integer" },
+        "first_name": { "type": "string" },
+        "last_name": { "type": "string" },
+        "year_of_birth": {
+          "type": "integer",
+          "maxValue": 2017
+        }
+      },
+      "required": [ "first_name", "last_name" ]
+    }
+  Authors: |
+    {
+      "$schema": "http://json-schema.org/schema",
+      "type": "array",
+      "description": "A list of authors",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "first_name": { "type": "string" },
+          "last_name": { "type": "string" },
+          "year_of_birth": {
+            "type": "integer",
+            "maxValue": 2017
+          }
+        }
+      }
+    }
+
+/authors:
+  post:
+    description: Add a new author to the system
+    responses:
+      204:
+        body:
+          application/json:
+            schema: Authors

--- a/spec/lib/raml/parser/root_spec.rb
+++ b/spec/lib/raml/parser/root_spec.rb
@@ -55,6 +55,22 @@ describe Raml::Parser::Root do
       its('documentation.count') { should == 0 }
       its('resources.first.http_methods.first.responses.first.bodies.first.type') { should == 'Authors' }
     end
-  end
 
+    context 'using schemas' do
+      let(:raml) { YAML.load File.read('spec/fixtures/basic_raml_with_schemas.raml') }
+      subject { Raml::Parser::Root.new.parse(raml) }
+
+      it { is_expected.to be_kind_of Raml::Root }
+      its(:base_uri) { should == 'http://api.e-bookmobile.com/{version}' }
+      its(:uri) { should == 'http://api.e-bookmobile.com/1.2' }
+      its(:version) { should == 1.2 }
+      its(:media_type) { should be_nil }
+      its('resources.count') { should == 1 }
+      its('resources.first.http_methods.count') { should == 1 }
+      its('resources.first.http_methods.first.responses.count') { should == 1 }
+      its('resources.first.http_methods.first.query_parameters.count') { should == 0 }
+      its('documentation.count') { should == 0 }
+      its('resources.first.http_methods.first.responses.first.bodies.first.schema') { should == 'Authors' }
+    end
+  end
 end


### PR DESCRIPTION
See #22 

This PR supports the `schemas` root key and `schema` key for the resource body.