### PR TITLE
Support description and displayName

### DIFF
--- a/lib/raml/method.rb
+++ b/lib/raml/method.rb
@@ -1,7 +1,8 @@
 module Raml
   class Method
 
-    attr_accessor :method, :description, :headers, :responses, :query_parameters, :bodies
+    attr_accessor :method, :description, :headers, :responses,
+                  :query_parameters, :bodies, :display_name
 
     def initialize(method)
       @method = method

--- a/lib/raml/parser/method.rb
+++ b/lib/raml/parser/method.rb
@@ -13,7 +13,7 @@ module Raml
       extend Forwardable
       include Raml::Parser::Util
 
-      BASIC_ATTRIBUTES = %w[description headers]
+      BASIC_ATTRIBUTES = %w[display_name description headers]
 
       attr_accessor :method, :parent, :attributes
       def_delegators :@parent, :traits

--- a/lib/raml/parser/resource.rb
+++ b/lib/raml/parser/resource.rb
@@ -13,6 +13,8 @@ module Raml
 
       HTTP_METHODS = %w[get put post delete]
 
+      BASIC_ATTRIBUTES = %w[display_name description]
+
       attr_accessor :parent_node, :resource, :trait_names, :attributes
       def_delegators :@parent, :traits, :resource_types
 
@@ -39,6 +41,8 @@ module Raml
               resource.resources << Raml::Parser::Resource.new(self).parse(resource, key, value)
             when *HTTP_METHODS
               resource.http_methods << Raml::Parser::Method.new(self).parse(key, value)
+            when *BASIC_ATTRIBUTES
+              resource.send("#{key}=", value)
             when 'is'
               @trait_names = value
             when 'uri_parameters'

--- a/lib/raml/parser/response.rb
+++ b/lib/raml/parser/response.rb
@@ -25,6 +25,8 @@ module Raml
             case key
             when 'body'
               parse_bodies(value)
+            when 'description'
+              response.description = value
             else
               raise UnknownAttributeError.new "Unknown response key: #{key}"
             end

--- a/lib/raml/resource.rb
+++ b/lib/raml/resource.rb
@@ -1,6 +1,7 @@
 module Raml
   class Resource
-    attr_accessor :parent, :http_methods, :uri_partial, :resources
+    attr_accessor :parent, :http_methods, :uri_partial, :resources,
+                  :display_name, :description
 
     def initialize(parent, uri_partial)
       @parent       = parent

--- a/lib/raml/response.rb
+++ b/lib/raml/response.rb
@@ -1,6 +1,6 @@
 module Raml
   class Response
-    attr_accessor :code, :bodies
+    attr_accessor :code, :bodies, :description
 
     def initialize(code)
       @code   = code

--- a/spec/fixtures/basic.raml
+++ b/spec/fixtures/basic.raml
@@ -27,8 +27,12 @@ traits:
   - notApplied:
       fake: value
 /songs:
+  displayName: Songs
+  description: Songs are really cool things
   is: [ paged ]
   get:
+    displayName: List songs
+    description: You might want to list songs.
     queryParameters:
       genre:
         description: filter the songs by genre
@@ -40,6 +44,7 @@ traits:
     get:
       responses:
         200:
+          description: A song is returned.
           body:
             application/json:
               schema: |


### PR DESCRIPTION
The presence of a displayName was causing the parsing to fail. According to the [1.0 spec](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md):

description should be supported by:
+ resources
+ methods
+ responses

displayName should be supported by:
+ resources
+ methods

Perhaps you could point me in a direction for how you'd like to test this functionality.